### PR TITLE
Add unit testing to Faucet.sol

### DIFF
--- a/contracts/Faucet.sol
+++ b/contracts/Faucet.sol
@@ -1,11 +1,32 @@
-//SPDX-License-Identifier: Unlicense
-pragma solidity ^0.8.0;
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
 
 contract Faucet {
-    function withdraw(uint256 _amount) public {
+    address payable public owner;
+
+    constructor() payable {
+        owner = payable(msg.sender);
+    }
+
+    function withdraw(uint256 _amount) public payable {
         // users can only withdraw .1 ETH at a time, feel free to change this!
-        require(_amount <= 100000000000000000);
-        payable(msg.sender).transfer(_amount);
+        require(_amount <= .1 ether); // 100000000000000000
+        (bool sent, ) = payable(msg.sender).call{value: _amount}("");
+        require(sent, "Failed to send Ether");
+    }
+
+    function withdrawAll() public onlyOwner {
+        (bool sent, ) = owner.call{value: address(this).balance}("");
+        require(sent, "Failed to send Ether");
+    }
+
+    function destroyFaucet() public onlyOwner {
+        selfdestruct(owner);
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
     }
 
     // fallback function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "deploy_contract_alchemy_university",
+  "name": "faucet_contract_alchemy_university",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "deploy_contract_alchemy_university",
+      "name": "faucet_contract_alchemy_university",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "deploy_contract_alchemy_university",
+  "name": "faucet_contract_alchemy_university",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -7,7 +7,7 @@
     "compile": "npx hardhat compile",
     "deploy_local": "npx hardhat run scripts/deploy.js",
     "deploy_goerli": "npx hardhat run scripts/deploy.js --network goerli",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npx hardhat test"
   },
   "keywords": [],
   "author": "skplunkerin",

--- a/test/testFaucet.js
+++ b/test/testFaucet.js
@@ -1,0 +1,111 @@
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const { expect } = require("chai");
+const { BigNumber } = require("ethers");
+
+describe("Faucet", function () {
+  // This fixture will be re-run in every test to setup the contract.
+  // Using loadFixture() to run this will create a snapshot of the contract
+  // state and reset the Hardhat Network to that snapshot in every test.
+  async function deployContractAndSetVariables() {
+    const [owner, otherAccount] = await ethers.getSigners();
+    const Faucet = await ethers.getContractFactory("Faucet");
+    // deploy the faucet with starting 2 ETH balance so the withdraw() functions
+    // actually work.
+    const faucet = await Faucet.deploy({
+      value: ethers.utils.parseUnits("2", "ether"),
+    });
+    const maxWithdrawAmount = ethers.utils.parseUnits(".1", "ether");
+
+    // console.log("Contract address :", faucet.address);
+    // console.log("Owner address :", owner.address);
+    // console.log(
+    //   "Contract balance:\n",
+    //   (await ethers.provider.getBalance(faucet.address))
+    //     .toBigInt()
+    //     .toLocaleString("en-US")
+    // );
+    // console.log(
+    //   "Owner balance:\n",
+    //   (await ethers.provider.getBalance(owner.address))
+    //     .toBigInt()
+    //     .toLocaleString("en-US")
+    // );
+    // console.log(
+    //   "Other account balance:\n",
+    //   (await ethers.provider.getBalance(owner.address))
+    //     .toBigInt()
+    //     .toLocaleString("en-US")
+    // );
+    // console.log("Other address:", otherAccount.address);
+
+    return { faucet, owner, otherAccount, maxWithdrawAmount };
+  }
+
+  it("should set the owner correctly from the constructor", async function () {
+    const { faucet, owner } = await loadFixture(deployContractAndSetVariables);
+    expect(await faucet.owner()).to.equal(owner.address);
+  });
+  it("withdraw() should send only .1 ETH", async function () {
+    const { faucet, owner, otherAccount, maxWithdrawAmount } =
+      await loadFixture(deployContractAndSetVariables);
+    // revert when withdraw amount is too high
+    const withdrawAmount = ethers.utils.parseUnits("1", "ether");
+    await expect(faucet.connect(otherAccount).withdraw(withdrawAmount)).to.be
+      .reverted;
+
+    // TODO: allow the correct withdraw amount
+    //
+    // Attempt 1:
+    // This isn't working... I want to get the contract balance before/after but
+    // it isn't changing (something might be wrong with the contract function?
+    // or I'm not doing something right here). [topher]
+    //
+    // const contractBalance = await ethers.provider.getBalance(faucet.address);
+    // await expect(faucet.connect(otherAccount).withdraw(maxWithdrawAmount));
+    // const newContractBalance = await ethers.provider.getBalance(faucet.address);
+    // // NOTE: the balance isn't changing like it's supposed to.
+    // expect(contractBalance).to.not.equal(newContractBalance);
+    //
+    // Attempt 2:
+    // this also doesn't work (there's probably something wrong with
+    // `Faucet.sol`):
+    //
+    // await expect(
+    //   faucet.connect(otherAccount).withdraw(maxWithdrawAmount)
+    // ).to.changeEtherBalances(
+    //   [faucet, otherAccount],
+    //   [-maxWithdrawAmount, maxWithdrawAmount]
+    // );
+    //
+    // Attempt 3 works:
+    // TODO: how to make the BigNumber negative? none of the below works:
+    //   maxWithdrawAmount * -1
+    //   maxWithdrawAmount.times(-1)
+    //   BigNumber(maxWithdrawAmount).times(-1)
+    const negativeMaxWithdrawAmount = ethers.utils.parseUnits("-.1", "ether");
+    // await expect(
+    //   faucet.connect(otherAccount).withdraw(maxWithdrawAmount)
+    // ).to.changeEtherBalance(faucet, negativeMaxWithdrawAmount);
+    await expect(
+      faucet.connect(otherAccount).withdraw(maxWithdrawAmount)
+    ).to.changeEtherBalances(
+      [faucet, otherAccount],
+      [negativeMaxWithdrawAmount, maxWithdrawAmount]
+    );
+  });
+  // TODO: Test the following:
+  // it("should restrict withdrawAll() to the owner via the onlyOwner modifier", async function () {
+  //   const { faucet, owner, otherAccount } = await loadFixture(
+  //     deployContractAndSetVariables
+  //   );
+  // });
+  // it("should restrict destroyFaucet() to the owner via the onlyOwner modifier", async function () {
+  //   const { faucet, owner } = await loadFixture(deployContractAndSetVariables);
+  // });
+  // it("withdrawAll() should send all funds to the owner", async function () {
+  //   const { faucet, owner } = await loadFixture(deployContractAndSetVariables);
+  // });
+  // it("destroyFaucet() should send all funds to the owner", async function () {
+  //   const { faucet, owner } = await loadFixture(deployContractAndSetVariables);
+  // });
+});

--- a/test/testFaucet.js
+++ b/test/testFaucet.js
@@ -45,6 +45,7 @@ describe("Faucet", function () {
     const { faucet, owner } = await loadFixture(deployContractAndSetVariables);
     expect(await faucet.owner()).to.equal(owner.address);
   });
+
   it("withdraw() should send only .1 ETH", async function () {
     const { faucet, owner, otherAccount, maxWithdrawAmount } =
       await loadFixture(deployContractAndSetVariables);
@@ -53,36 +54,12 @@ describe("Faucet", function () {
     await expect(faucet.connect(otherAccount).withdraw(withdrawAmount)).to.be
       .reverted;
 
-    // TODO: allow the correct withdraw amount
-    //
-    // Attempt 1:
-    // This isn't working... I want to get the contract balance before/after but
-    // it isn't changing (something might be wrong with the contract function?
-    // or I'm not doing something right here). [topher]
-    //
-    // const contractBalance = await ethers.provider.getBalance(faucet.address);
-    // await expect(faucet.connect(otherAccount).withdraw(maxWithdrawAmount));
-    // const newContractBalance = await ethers.provider.getBalance(faucet.address);
-    // // NOTE: the balance isn't changing like it's supposed to.
-    // expect(contractBalance).to.not.equal(newContractBalance);
-    //
-    // Attempt 2:
-    // this also doesn't work (there's probably something wrong with
-    // `Faucet.sol`):
-    //
-    // await expect(
-    //   faucet.connect(otherAccount).withdraw(maxWithdrawAmount)
-    // ).to.changeEtherBalances(
-    //   [faucet, otherAccount],
-    //   [-maxWithdrawAmount, maxWithdrawAmount]
-    // );
-    //
-    // Attempt 3 works:
     // TODO: how to make the BigNumber negative? none of the below works:
     //   maxWithdrawAmount * -1
     //   maxWithdrawAmount.times(-1)
     //   BigNumber(maxWithdrawAmount).times(-1)
     const negativeMaxWithdrawAmount = ethers.utils.parseUnits("-.1", "ether");
+    // to just check the balance changing to the contract or address:
     // await expect(
     //   faucet.connect(otherAccount).withdraw(maxWithdrawAmount)
     // ).to.changeEtherBalance(faucet, negativeMaxWithdrawAmount);
@@ -93,19 +70,31 @@ describe("Faucet", function () {
       [negativeMaxWithdrawAmount, maxWithdrawAmount]
     );
   });
+
+  it("should restrict destroyFaucet() to the owner via the onlyOwner modifier", async function () {
+    const { faucet, owner, otherAccount } = await loadFixture(
+      deployContractAndSetVariables
+    );
+
+    // another address can't call destroyFaucet()
+    await expect(faucet.connect(otherAccount).destroyFaucet()).to.be.reverted;
+
+    // the owner can call destroyFaucet()
+    await expect(faucet.connect(owner).destroyFaucet());
+    let bytecode = await ethers.provider.getCode(faucet.address);
+    expect(bytecode).equal("0x");
+  });
+
   // TODO: Test the following:
   // it("should restrict withdrawAll() to the owner via the onlyOwner modifier", async function () {
   //   const { faucet, owner, otherAccount } = await loadFixture(
   //     deployContractAndSetVariables
   //   );
   // });
-  // it("should restrict destroyFaucet() to the owner via the onlyOwner modifier", async function () {
+  // it("destroyFaucet() should send all funds to the owner", async function () {
   //   const { faucet, owner } = await loadFixture(deployContractAndSetVariables);
   // });
   // it("withdrawAll() should send all funds to the owner", async function () {
-  //   const { faucet, owner } = await loadFixture(deployContractAndSetVariables);
-  // });
-  // it("destroyFaucet() should send all funds to the owner", async function () {
   //   const { faucet, owner } = await loadFixture(deployContractAndSetVariables);
   // });
 });


### PR DESCRIPTION
## New

* WIP: Add new `testFaucet.js` tests

## Updates

* Update contract `Faucet.sol`:
  - Change license to MIT (🤷)
  - Increase version to `^0.8.17`
  - Add public `owner` variable with constructor that sets the value
  - Add new functions `withdrawAll()`, `destroyFaucet()`, and `onlyOwner` modifier
  - Update `withdraw()` to be payable

* Update `package.json`:
  - Rename package to match repo name
  - Update `test` script to run hardhat tests